### PR TITLE
Update subject types and upgrades

### DIFF
--- a/common/subject_type_upgrades/00_subject_type_upgrades.txt
+++ b/common/subject_type_upgrades/00_subject_type_upgrades.txt
@@ -4,14 +4,17 @@
 increase_force_limit_from_colony = {
 	can_upgrade_trigger = {
 		is_subject_of_type = crown_colony
-		adm_power = 25
+		colonial_parent = {
+			adm_power = 25
+		}
 	}
 	
 	cost = 100
 	
 	effect = {
-		add_liberty_desire = 10
-		add_adm_power = -25
+		colonial_parent = {
+			add_adm_power = -25
+		}
 	}
 
 	modifier_overlord = {
@@ -20,41 +23,62 @@ increase_force_limit_from_colony = {
 
 	modifier_subject = {
 		land_forcelimit = -5
+		liberty_desire = 10
 	}
 }
 
 enlarge_the_gold_fleet = {
 	can_upgrade_trigger = {
 		is_subject_of_type = crown_colony
-		adm_power = 25
+		colonial_parent = {
+			adm_power = 25
+		}
 	}
 	
 	cost = 100
 	
 	effect = {
-		add_liberty_desire = 10
-		add_adm_power = -25
+		colonial_parent = {
+			add_adm_power = -25
+		}
 	}
 
 	modifier_overlord = {
 		treasure_fleet_income = 0.2
+	}
+
+	modifier_subject = {
+		liberty_desire = 10
 	}
 }
 
 increase_religious_control = {
 	can_upgrade_trigger = {
 		is_subject_of_type = crown_colony
-		adm_power = 25
+		colonial_parent = {
+			adm_power = 25
+		}
 	}
 	
 	cost = 100
 	
 	effect = {
-		add_liberty_desire = 10
-		add_adm_power = -25
+		colonial_parent = {
+			add_adm_power = -25
+		}
+		hidden_effect = {
+			set_country_flag = has_increased_religious_control
+		}
+	}
+
+	removed_effect = {
+		hidden_effect = {
+			clr_country_flag = has_increased_religious_control
+		}
 	}
 
 	modifier_subject = {
+		liberty_desire = 10
 		global_missionary_strength = 0.01
 		tolerance_heathen = -1
 	}
@@ -63,14 +87,17 @@ increase_religious_control = {
 increase_integration_in_the_realm = {
 	can_upgrade_trigger = {
 		is_subject_of_type = crown_colony
-		adm_power = 25
+		colonial_parent = {
+			adm_power = 25
+		}
 	}
 	
 	cost = 100
 	
 	effect = {
-		add_liberty_desire = -10
-		add_adm_power = -25
+		colonial_parent = {
+			add_adm_power = -25
+		}
 	}
 
 	modifier_overlord = {
@@ -86,14 +113,17 @@ increase_integration_in_the_realm = {
 increase_trade_power_transfer_from_colony = {
 	can_upgrade_trigger = {
 		is_subject_of_type = private_enterprise
-		adm_power = 25
+		colonial_parent = {
+			adm_power = 25
+		}
 	}
 	
 	cost = 100
 	
 	effect = {
-		add_liberty_desire = 10
-		add_adm_power = -25
+		colonial_parent = {
+			add_adm_power = -25
+		}
 	}
 
 	modifier_overlord = {
@@ -101,6 +131,7 @@ increase_trade_power_transfer_from_colony = {
 	}
 
 	modifier_subject = {
+		liberty_desire = 10
 		global_trade_power = -0.02
 	}
 }
@@ -108,30 +139,41 @@ increase_trade_power_transfer_from_colony = {
 encourage_cash_crops = {
 	can_upgrade_trigger = {
 		is_subject_of_type = private_enterprise
-		adm_power = 25
+		colonial_parent = {
+			adm_power = 25
+		}
 	}
 	
 	cost = 100
 	
 	effect = {
-		add_liberty_desire = 10
-		add_adm_power = -25
+		colonial_parent = {
+			add_adm_power = -25
+		}
 		custom_tooltip = encourage_cash_crops_tt
 		set_country_flag = encourage_cash_crops_flag
+	}
+
+	modifier_subject = {
+		liberty_desire = 10
+		global_trade_power = -0.02
 	}
 }
 
 increase_naval_force_limit_from_colony = {
 	can_upgrade_trigger = {
 		is_subject_of_type = private_enterprise
-		adm_power = 25
+		colonial_parent = {
+			adm_power = 25
+		}
 	}
 	
 	cost = 100
 	
 	effect = {
-		add_liberty_desire = 10
-		add_adm_power = -25
+		colonial_parent = {
+			add_adm_power = -25
+		}
 	}
 
 	modifier_overlord = {
@@ -140,20 +182,24 @@ increase_naval_force_limit_from_colony = {
 
 	modifier_subject = {
 		naval_forcelimit = -5
+		liberty_desire = 10
 	}
 }
 
 increase_the_gold_tax = {
 	can_upgrade_trigger = {
 		is_subject_of_type = private_enterprise
-		adm_power = 25
+		colonial_parent = {
+			adm_power = 25
+		}
 	}
 	
 	cost = 100
 	
 	effect = {
-		add_liberty_desire = 10
-		add_adm_power = -25
+		colonial_parent = {
+			add_adm_power = -25
+		}
 	}
 
 	modifier_overlord = {
@@ -162,6 +208,7 @@ increase_the_gold_tax = {
 	
 	modifier_subject = {
 		global_tax_modifier = -0.05
+		liberty_desire = 10
 	}
 }
 
@@ -169,13 +216,17 @@ increase_the_gold_tax = {
 allow_autonomous_trade = {
 	can_upgrade_trigger = {
 		is_subject_of_type = self_governing_colony
-		adm_power = 25
+		colonial_parent = {
+			adm_power = 25
+		}
 	}
 	
 	cost = 100
 
 	effect = {
-		add_adm_power = -25
+		colonial_parent = {
+			add_adm_power = -25
+		}
 	}
 	
 	modifier_subject = {
@@ -187,13 +238,17 @@ allow_autonomous_trade = {
 allow_autonomous_taxing = {
 	can_upgrade_trigger = {
 		is_subject_of_type = self_governing_colony
-		adm_power = 25
+		colonial_parent = {
+			adm_power = 25
+		}
 	}
 	
 	cost = 100
 
 	effect = {
-		add_adm_power = -25
+		colonial_parent = {
+			add_adm_power = -25
+		}
 	}
 	
 	modifier_subject = {
@@ -205,13 +260,17 @@ allow_autonomous_taxing = {
 allow_autonomous_militias = {
 	can_upgrade_trigger = {
 		is_subject_of_type = self_governing_colony
-		adm_power = 25
+		colonial_parent = {
+			adm_power = 25
+		}
 	}
 	
 	cost = 100
 	
 	effect = {
-		add_adm_power = -25
+		colonial_parent = {
+			add_adm_power = -25
+		}
 	}
 
 	modifier_subject = {
@@ -223,13 +282,17 @@ allow_autonomous_militias = {
 allow_autonomous_navy = {
 	can_upgrade_trigger = {
 		is_subject_of_type = self_governing_colony
-		adm_power = 25
+		colonial_parent = {
+			adm_power = 25
+		}
 	}
 	
 	cost = 100
 	
 	effect = {
-		add_adm_power = -25
+		colonial_parent = {
+			add_adm_power = -25
+		}
 	}
 
 	modifier_subject = {
@@ -242,13 +305,17 @@ allow_autonomous_navy = {
 allow_autonomous_trade = {
 	can_upgrade_trigger = {
 		is_subject_of_type = self_governing_dominion_vu
-		adm_power = 25
+		colonial_parent = {
+			adm_power = 25
+		}
 	}
 	
 	cost = 100
 
 	effect = {
-		add_adm_power = -25
+		colonial_parent = {
+			add_adm_power = -25
+		}
 	}
 	
 	modifier_subject = {
@@ -260,13 +327,17 @@ allow_autonomous_trade = {
 allow_autonomous_taxing = {
 	can_upgrade_trigger = {
 		is_subject_of_type = self_governing_dominion_vu
-		adm_power = 25
+		colonial_parent = {
+			adm_power = 25
+		}
 	}
 	
 	cost = 100
 
 	effect = {
-		add_adm_power = -25
+		colonial_parent = {
+			add_adm_power = -25
+		}
 	}
 	
 	modifier_subject = {
@@ -278,13 +349,17 @@ allow_autonomous_taxing = {
 allow_autonomous_militias = {
 	can_upgrade_trigger = {
 		is_subject_of_type = self_governing_dominion_vu
-		adm_power = 25
+		colonial_parent = {
+			adm_power = 25
+		}
 	}
 	
 	cost = 100
 	
 	effect = {
-		add_adm_power = -25
+		colonial_parent = {
+			add_adm_power = -25
+		}
 	}
 
 	modifier_subject = {
@@ -296,13 +371,17 @@ allow_autonomous_militias = {
 allow_autonomous_navy = {
 	can_upgrade_trigger = {
 		is_subject_of_type = self_governing_dominion_vu
-		adm_power = 25
+		colonial_parent = {
+			adm_power = 25
+		}
 	}
 	
 	cost = 100
 	
 	effect = {
-		add_adm_power = -25
+		colonial_parent = {
+			add_adm_power = -25
+		}
 	}
 
 	modifier_subject = {
@@ -315,13 +394,17 @@ allow_autonomous_navy = {
 allow_autonomous_trade = {
 	can_upgrade_trigger = {
 		is_subject_of_type = self_governing_super_dominion_vu
-		adm_power = 25
+		colonial_parent = {
+			adm_power = 25
+		}
 	}
 	
 	cost = 100
 
 	effect = {
-		add_adm_power = -25
+		colonial_parent = {
+			add_adm_power = -25
+		}
 	}
 	
 	modifier_subject = {
@@ -333,13 +416,17 @@ allow_autonomous_trade = {
 allow_autonomous_taxing = {
 	can_upgrade_trigger = {
 		is_subject_of_type = self_governing_super_dominion_vu
-		adm_power = 25
+		colonial_parent = {
+			adm_power = 25
+		}
 	}
 	
 	cost = 100
 
 	effect = {
-		add_adm_power = -25
+		colonial_parent = {
+			add_adm_power = -25
+		}
 	}
 	
 	modifier_subject = {
@@ -351,13 +438,17 @@ allow_autonomous_taxing = {
 allow_autonomous_militias = {
 	can_upgrade_trigger = {
 		is_subject_of_type = self_governing_super_dominion_vu
-		adm_power = 25
+		colonial_parent = {
+			adm_power = 25
+		}
 	}
 	
 	cost = 100
 	
 	effect = {
-		add_adm_power = -25
+		colonial_parent = {
+			add_adm_power = -25
+		}
 	}
 
 	modifier_subject = {
@@ -369,13 +460,17 @@ allow_autonomous_militias = {
 allow_autonomous_navy = {
 	can_upgrade_trigger = {
 		is_subject_of_type = self_governing_super_dominion_vu
-		adm_power = 25
+		colonial_parent = {
+			adm_power = 25
+		}
 	}
 	
 	cost = 100
 	
 	effect = {
-		add_adm_power = -25
+		colonial_parent = {
+			add_adm_power = -25
+		}
 	}
 
 	modifier_subject = {

--- a/common/subject_types/00_subject_types.txt
+++ b/common/subject_types/00_subject_types.txt
@@ -8,7 +8,7 @@
 
 # count = x is used (means it "counts as" x in some triggers).
 
-# copy_from copies everything except count, is_potential_overlord, and can_be_established
+# copy_from copies everything except count and is_potential_overlord
 
 # relative_power_class decides how Subjects are grouped together when considering relative strenghth towards overlord:
 # If it is 0 they won't consider relative power and if it is 1 they will only consider their own power (and those supporting their independence) compared to their Overlord's.
@@ -109,6 +109,7 @@ default = {
 	manpower_to_overlord = 0.0							# Percent of subject FL to use as base for modifiers
 	sailors_to_overlord = 0.0							# Percent of subject FL to use as base for modifiers
 	military_focus = 1.0								# How much the AI subject should spend etc. on army and forts. 0 should make them spend nothing. Very high values will probably not make a big difference since there will be sanity checks.
+	annex_cost_per_development = 8.0					# annex/integrate cost per development
 
 	relative_power_class = 1 							# See description above
 	should_quit_wars_on_activation = yes
@@ -222,6 +223,23 @@ vassal = {
 	modifier_overlord = {
 		modifier = vassal_subject
 	}
+	modifier_overlord = {
+		modifier = pirate_subject
+		trigger = {
+			has_government_attribute = is_pirate_republic_reform
+			overlord = {
+				has_government_attribute = pirate_vassal_bonus
+			}
+		}
+	}
+	modifier_subject = {
+		modifier = subject_tax_modifier
+		trigger = {
+			overlord = {
+				has_government_attribute = subject_tax_modifier_25
+			}
+		}
+	}
 
 	overlord_opinion_modifier = is_vassal
 	subject_opinion_modifier = is_vassal
@@ -269,6 +287,14 @@ march = {
 		}
 		expiration_message_overlord = MARCHTOOLARGE
 		expiration_message_subject = MARCHTOOLARGEUS
+	}
+	modifier_subject = {
+		modifier = subject_tax_modifier
+		trigger = {
+			overlord = {
+				has_government_attribute = subject_tax_modifier_25
+			}
+		}
 	}
 }
 
@@ -386,6 +412,18 @@ personal_union = {
 	modifier_overlord = {
 		modifier = union_subject
 	}
+	modifier_overlord = {
+		trigger = {
+			overlord = { has_government_attribute = personal_union_war_contribution }
+		}
+		modifier = pu_overlord_bonus
+	}
+	modifier_subject = {
+		trigger = {
+			overlord = { has_government_attribute = personal_union_war_contribution }
+		}
+		modifier = pu_subject_bonus
+	}
 
 	overlord_opinion_modifier = in_union
 	subject_opinion_modifier = in_union
@@ -488,12 +526,19 @@ colony = {
 	start_colonial_war = yes
 	increase_tariffs = yes
 	decrease_tariffs = yes
+	enforce_culture = yes
 
 	# Modifiers:
 	modifier_overlord = {
 		modifier = large_colonial_nation
 		trigger = {
 			num_of_cities = 10
+		}
+	}
+	modifier_subject = {
+		modifier = new_world_exploitation_modifier
+		trigger = {
+			overlord = { has_government_attribute = extra_trade_goods_for_colonial_subjects }
 		}
 	}
 
@@ -510,10 +555,10 @@ crown_colony = {
 	can_send_missionary_to_subject = yes
 	count = colony
 
-	forcelimit_to_overlord = 0.5
-	manpower_to_overlord = 0.5
-	naval_forcelimit_to_overlord = 0.05
-	sailors_to_overlord = 0.05
+	forcelimit_to_overlord = 0.3
+	manpower_to_overlord = 0.3
+	naval_forcelimit_to_overlord = 0.01
+	sailors_to_overlord = 0.01
 
 	# Subject Interactions:
 	customize_subject = yes
@@ -525,6 +570,7 @@ crown_colony = {
 	takeondebt = yes
 	block_settlement_growth = yes
 	allow_settlement_growth = yes
+	enforce_culture = yes
 	
 	# Modifiers:
 	modifier_overlord = clear
@@ -547,13 +593,15 @@ private_enterprise = {
 
 	forcelimit_to_overlord = 0.0
 	manpower_to_overlord = 0.0
-	sailors_to_overlord = 0.5
+	naval_forcelimit_to_overlord = 0.3
+	sailors_to_overlord = 0.3
 
 	# Subject Interactions:
 	customize_subject = yes
 	replace_governor = no
 	block_settlement_growth = no
 	allow_settlement_growth = no
+	enforce_culture = yes
 	
 	# Modifiers:	
 	modifier_overlord = clear
@@ -574,10 +622,10 @@ self_governing_colony = {
 	is_colony_subtype = yes
 	count = colony
 
-	forcelimit_to_overlord = 0.05
-	manpower_to_overlord = 0.05
-	naval_forcelimit_to_overlord = 0.05
-	sailors_to_overlord = 0.05
+	forcelimit_to_overlord = 0.002
+	manpower_to_overlord = 0.002
+	naval_forcelimit_to_overlord = 0.002
+	sailors_to_overlord = 0.002
 
 	# Subject Interactions:
 	customize_subject = yes
@@ -585,6 +633,7 @@ self_governing_colony = {
 	block_settlement_growth = no
 	allow_settlement_growth = no
 	press_sailors = no
+	enforce_culture = yes
 	
 	# Modifiers:	
 	modifier_overlord = clear
@@ -705,19 +754,24 @@ tributary_state = {
 
 	# Triggers:
 	is_potential_overlord = {
-		has_dlc = "Mandate of Heaven"
-		NOT = { 
-			is_subject_of_type = tributary_state
-		}
 		OR = {
-			has_reform = celestial_empire
-			has_government_attribute = has_tributaries
-			has_country_flag = can_create_tributaries_flag
-			has_country_flag = can_create_tributaries_flag_estate
-			is_nomad = yes
-			religion_group = eastern
-			technology_group = chinese
-			technology_group = polynesian_tech
+			AND = {
+				has_dlc = "Mandate of Heaven"
+				NOT = { 
+					is_subject_of_type = tributary_state
+				}
+				OR = {
+					has_reform = celestial_empire
+					has_government_attribute = has_tributaries
+					has_country_flag = can_create_tributaries_flag
+					has_country_flag = can_create_tributaries_flag_estate
+					is_nomad = yes
+					religion_group = eastern
+					technology_group = chinese
+					technology_group = polynesian_tech
+				}
+			}
+			has_country_flag = forced_tributary_state	#A special flag for the Ottomans so they can get Crimea without allowing them to make tributaries by default
 		}
 	}
 	


### PR DESCRIPTION
Updates from the base game. This should fix the diplo annex bug where the cost becomes is almost zero. The fix is the "annex_cost_per_development = 8.0" line. It was originally in the "defines" file, but it was moved to here in the new update.

Here is the relevant line from the patch notes:
"- Subject types now have annex_cost_per_development to replace the old define of ANNEX_DIP_COST_PER_DEVELOPMENT."